### PR TITLE
Add a second parameter to simple indexing script

### DIFF
--- a/index_current_repo.py
+++ b/index_current_repo.py
@@ -5,24 +5,36 @@ import json, urllib2, pycurl, sys
 def submit_request(data):
     '''Send a request to oti to index a single study. URL is set to default neo4j location'''
     c = pycurl.Curl()
-    c.setopt(c.URL, oti_url + "ext/IndexServices/graphdb/indexSingleNexson")
+    url = oti_url + "ext/IndexServices/graphdb/indexSingleNexson"
+    c.setopt(c.URL, url)
     c.setopt(c.HTTPHEADER, ["Content-type:Application/json"])
     c.setopt(c.POSTFIELDS, data)
     c.setopt(c.VERBOSE, True)
+    # Operates asynchronously I think... we need to wait for it to finish.
+    # Also it exits without waiting for all transfers to complete.
+    # These pile up, and we get 403 responses!
     c.perform()
 
-files_base_url = "https://raw.github.com/OpenTreeOfLife/treenexus/master"
-studies_url = "https://api.github.com/repos/OpenTreeOfLife/treenexus/contents/study"
-studies = urllib2.urlopen(studies_url)
-
-oti_url = "http://localhost:7474/db/data/"
 if len(sys.argv) > 1:
     oti_url = sys.argv[1].rstrip("/") + "/"
+else:
+    oti_url = "http://localhost:7474/db/data/"
 
-for study in json.loads(studies.read()):
-    
+if len(sys.argv) > 2:
+    oti_repo = sys.argv[2]
+else:
+    oti_repo = 'treenexus'
+
+files_base_url = "https://raw.github.com/OpenTreeOfLife/%s/master"%(oti_repo)
+studies_url = "https://api.github.com/repos/OpenTreeOfLife/%s/contents/study"%(oti_repo)
+studies = urllib2.urlopen(studies_url)
+
+study_list = studies.read()
+print " Indexing %s studies from %s"%(len(study_list), oti_repo)
+
+for study in json.loads(study_list):
     study_id = study["name"]
-    print "indexing study " + study_id
+    print "Indexing %s study %s"%(oti_repo, study_id)
     data = {"url" : "/".join([files_base_url, "study", study_id, study_id + ".json"])}
     submit_request(json.dumps(data))
 


### PR DESCRIPTION
Studies can come from the treenexus repo, the treenexus_test repo, or elsewhere. The new second command line parameter to the index_current_repo python script specifies which repo to read to get the complete corpus of studies.
