### PR TITLE
Skips over metadata properties with null value.

### DIFF
--- a/src/main/java/org/opentree/oti/DatabaseManager.java
+++ b/src/main/java/org/opentree/oti/DatabaseManager.java
@@ -491,6 +491,9 @@ public class DatabaseManager extends OTIDatabase {
 	private static void setNodePropertiesFromMap(Node node, Map<String, Object> properties) {
 		for (Entry<String, Object> property : properties.entrySet()) {
 			Object v = property.getValue();
+			
+			// workaround for current issue where incoming NexSON from phylesystem contains invalid null property values.
+			// should revert to strict requirements (i.e. throw an exception) once the issue in phylesystem is fixed.
 			if (v != null) {
 				node.setProperty(property.getKey(), property.getValue());
 			}


### PR DESCRIPTION
Perhaps we should be logging these, because I
don't think that this is legal NexSON. But some
are making it into the phylesystem_test repo.
I'll submit an issue there, but this is a
workaround.
