### PR TITLE
fixing bugs with incomplete NexsonNode methods

### DIFF
--- a/index_current_repo.py
+++ b/index_current_repo.py
@@ -6,80 +6,78 @@
 
 import json, os, requests, sys, tarfile, urllib2
 
-def get_download_dir():
-	d = os.path.abspath(os.path.expanduser("~/Downloads"))
-	if not os.path.exists(d):
-		os.mkdir(d)
-	return d
+def main():
 
-def submit_indexing_request(data):
-	'''Send a request to oti to index a single study. URL is set to default neo4j location'''
-#	url = oti_url + "ext/IndexServices/graphdb/indexNexsons"
-	url = oti_url + "ext/studies/graphdb/index_studies"
+    # default args
+    if len(sys.argv) > 1:
+        oti_url = sys.argv[1].strip("/") + "/"
+    else:
+        # default could be 'http://127.0.0.1:7478/db/data/'
+        print("usage (with defaults): index_current_repo.py <oti_url> [<target_phylesystem_repo_name>](==http://localhost/api/)")
+        sys.exit(0)
+    print("Using the oti instance at: " + oti_url) 
+
+    if len(sys.argv) > 2:
+        api_url = sys.argv[2].strip("/") + "/"
+    else:
+        api_url = "http://localhost/phylesystem/"
+    #files_base_url = "https://raw.github.com/OpenTreeOfLife/%s/master"%(oti_repo)
+    print("Using the studies from: " + api_url) 
+
+    # Ignoring oti_mode for now, since we're using the local API to retrieve study
+    # ids and NexSON in the required format.
+    #
+    ##if len(sys.argv) > 3:
+    ##	oti_mode = sys.argv[3]
+    ##else:
+    ##	oti_mode = 'github'
+    ##if oti_mode == 'github':
+    ##	make_url = lambda study_id: "/".join([files_base_url, "study", study_id, study_id + ".json"])
+    ##elif oti_mode == 'local':
+    ##    # this is used during initial docstore indexing
+    ##	make_url = lambda study_id: "http://localhost/api/default/v1/study/{}.json".format(study_id)
+    ##else:
+    ##    print("Unrecognized mode {}".format(oti_mode))
+
+    make_study_url = lambda study_id: api_url + "default/v1/study/{}.json".format(study_id)
+
+    # right now we are not loading the taxonomy, any taxonomy must be provided as a pre-built database
+
+    # retrieve the study list
+    r = requests.get(api_url + "study_list")
+    r.raise_for_status()
+
+    study_list = r.json()
+    print(" Indexing {} studies from {}".format(len(study_list), api_url))
+
+    for study_id in study_list:
+        url = make_study_url(study_id)
+        print("Indexing study {} from {}".format(study_id, url))
+        try:
+            r = submit_indexing_request(oti_url, {"url" : url })
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("\nIndexing failed for " + url + "\n\n" + (e.message if hasattr(e, "message") else "(unknown error)") + "\n")
+	        # j = r.json()
+            print(r.text + '\n')
+        else:
+            print('OK\n')
+
+def submit_indexing_request(oti_url, data):
+	'''Send a request to OTI to index a single study. URL is set to default neo4j location'''
+	url = oti_url + "ext/studies/graphdb/index_study"
 	print 'Calling "{}" with data="{}"'.format(url, repr(data))
 	r = requests.post(url,
 					  data=json.dumps(data),
 					  headers={'Content-type': 'application/json'});
 	# We don't really need any data out of r.
 	# But do raise an error if something went wrong.
-	r.raise_for_status()
-	return r.json()
+	return r
 
-# default args
-if len(sys.argv) > 1:
-	oti_url = sys.argv[1].rstrip("/") + "/"
-	# local oti url (example): http://localhost:7474/db/data/
-else:
-	print("usage (with defaults): index_current_repo.py <oti_url> [<target_phylesystem_repo_name>](==http://localhost/api/)")
-	sys.exit(0)
-print("Using the oti instance at: " + oti_url) 
+main()
 
-if len(sys.argv) > 2:
-	api_url = sys.argv[2].strip("/") + "/"
-else:
-	api_url = "http://localhost/api/"
-#files_base_url = "https://raw.github.com/OpenTreeOfLife/%s/master"%(oti_repo)
-print("Using the studies from: " + api_url) 
 
-# Ignoring oti_mode for now, since we're using the local API to retrieve study
-# ids and NexSON in the required format.
-#
-##if len(sys.argv) > 3:
-##	oti_mode = sys.argv[3]
-##else:
-##	oti_mode = 'github'
-##if oti_mode == 'github':
-##	make_url = lambda study_id: "/".join([files_base_url, "study", study_id, study_id + ".json"])
-##elif oti_mode == 'local':
-##    # this is used during initial docstore indexing
-##	make_url = lambda study_id: "http://localhost/api/default/v1/study/{}.json".format(study_id)
-##else:
-##    print("Unrecognized mode {}".format(oti_mode))
-make_url = lambda study_id: api_url + "default/v1/study/{}.json".format(study_id) #"http://localhost/api/default/v1/study/{}.json".format(study_id)
 
-# or get studies from the API: ...
-# files_base_url = "http://localhost/api/default/v1/study/9.json"
-# PROBLEM: URL formation are rules in the two cases.
-
-# right now we are not loading the taxonomy, any taxonomy must be provided as a pre-built database
-
-# retrieve the study list
-r = requests.get(api_url + "study_list")
-r.raise_for_status()
-
-study_list = r.json()
-print(" Indexing {} studies from {}".format(len(study_list), api_url))
-
-for study_id in study_list:
-	url = make_url(study_id)
-	print("Indexing {} study {} from {}".format(api_url, study_id, url))
-	try:
-		r = submit_indexing_request({"urls" : [url] })
-	except requests.exceptions.HTTPError as e:
-		print("\nIndexing failed for " + url + "\n\n" + (e.message if hasattr(e, "message") else "(unknown error)") + "\n")
-	else:
-		for k, v in r['errors'].items():
-			print('\nIndexing failed for URL "{u}", study {s}. Message = "{v}"'.format(u=url, s=k, v=v))
 
 
 # additional code that is not currently used but may come in handy below here

--- a/src/main/java/org/opentree/oti/DatabaseManager.java
+++ b/src/main/java/org/opentree/oti/DatabaseManager.java
@@ -362,14 +362,14 @@ public class DatabaseManager extends OTIDatabase {
 	
 	/**
 	 * A recursive function used to replicate the tree JadeNode structure below the passed in JadeNode in the graph.
-	 * @param curJadeNode
+	 * @param curNexsonNode
 	 * @param parentGraphNode
 	 * @return
 	 */
-	private Node preorderAddTreeToDB(TreeNode curJadeNode, Node parentGraphNode) {
+	private Node preorderAddTreeToDB(NexsonNode curNexsonNode, Node parentGraphNode) {
 
 		Node curGraphNode = graphDb.createNode();
-		NexsonNode curNexsonNode = (NexsonNode) ((JadeNode)curJadeNode).getObject(NexsonNode.NEXSON_NODE_JADE_OBJECT_KEY);
+//		NexsonNode curNexsonNode = (NexsonNode) ((JadeNode)curJadeNode).getObject(NexsonNode.NEXSON_NODE_JADE_OBJECT_KEY);
 
 		// remember the ingroup if we hit one // TODO: might be able to clean this up by using the tree property set during nexson parsing...
 		if (curNexsonNode.hasProperty(OTINodeProperty.IS_INGROUP_ROOT.propertyName())) {
@@ -396,8 +396,8 @@ public class DatabaseManager extends OTIDatabase {
 			curGraphNode.createRelationshipTo(parentGraphNode, OTIRelType.CHILDOF);
 		}
 
-		for (TreeNode childJadeNode : curJadeNode.getChildren()) {
-			preorderAddTreeToDB(childJadeNode, curGraphNode);
+		for (TreeNode child : curNexsonNode.getChildren()) {
+			preorderAddTreeToDB((NexsonNode) child, curGraphNode);
 		}
 
 		indexer.addTreeNodeToIndexes(curGraphNode);
@@ -438,7 +438,8 @@ public class DatabaseManager extends OTIDatabase {
 		
 		for (TreeNode tip : tree.getRoot().getDescendantLeaves()) {
 			
-			NexsonOTU otu = ((NexsonNode) ((JadeNode)tip).getObject(NexsonNode.NEXSON_NODE_JADE_OBJECT_KEY)).getOTU();
+//			NexsonOTU otu = ((NexsonNode) ((JadeNode)tip).getObject(NexsonNode.NEXSON_NODE_JADE_OBJECT_KEY)).getOTU();
+			NexsonOTU otu = ((NexsonNode) tip).getOTU();
 
 			if (otu != null) { // TODO: this indicates invalid nexson: the otu assigned to this tip cannot be found. should we even allow this case?
 				

--- a/src/main/java/org/opentree/oti/plugins/IndexServices.java
+++ b/src/main/java/org/opentree/oti/plugins/IndexServices.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.opentree.MessageLogger;
 import org.opentree.graphdb.DatabaseUtils;
 import org.opentree.nexson.io.NexsonReader;
 import org.opentree.nexson.io.NexsonSource;
+import org.opentree.nexson.io.NexsonTree;
 import org.opentree.oti.QueryRunner;
 import org.opentree.oti.DatabaseManager;
 import org.opentree.oti.indexproperties.IndexedPrimitiveProperties;
@@ -90,22 +92,26 @@ public class IndexServices extends ServerPlugin {
 		}
 		
 		ArrayList<String> indexedIDs = new ArrayList<String>(urls.length);
+		HashMap<String, String> idsWithStacktraces = new HashMap<String, String>();
 		HashMap<String, String> idsWithErrors = new HashMap<String, String>();
+		HashMap<String, String> typesWithErrors = new HashMap<String, String>();
 		DatabaseManager manager = new DatabaseManager(graphDb);
 		for (int i = 0; i < urls.length; i++) {
 			try {
 				NexsonSource study = readRemoteNexson(urls[i]);
-//				if (study.getTrees().iterator().hasNext()) {
-					manager.addOrReplaceStudy(study);
-					indexedIDs.add(study.getId());
-//				}
+				manager.addOrReplaceStudy(study);
+				indexedIDs.add(study.getId());
 			} catch (Exception ex) {
+				idsWithStacktraces.put(urls[i], Arrays.toString(ex.getStackTrace()));
 				idsWithErrors.put(urls[i], ex.getMessage());
+				typesWithErrors.put(urls[i], ex.getClass().getName());
 			}
 		}
 		HashMap<String, Object> results = new HashMap<String, Object>(); // will be converted to JSON object
 		results.put("indexed", indexedIDs);
 		results.put("errors", idsWithErrors);
+		results.put("error_types", typesWithErrors);
+		results.put("stack_traces", idsWithStacktraces);
 		return OTRepresentationConverter.convert(results);
 
 	}

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -182,9 +182,6 @@ public class studies extends ServerPlugin {
 		}
 		
 		ArrayList<String> indexedIDs = new ArrayList<String>(urls.length);
-		HashMap<String, String> idsWithErrors = new HashMap<String, String>();
-		HashMap<String, String> idsWithStacktraces = new HashMap<String, String>();
-		HashMap<String, String> typesWithErrors = new HashMap<String, String>();
 		DatabaseManager manager = new DatabaseManager(graphDb);
 		for (int i = 0; i < urls.length; i++) {
 			NexsonSource study = readRemoteNexson(urls[i]);
@@ -193,9 +190,7 @@ public class studies extends ServerPlugin {
 		}
 		HashMap<String, Object> results = new HashMap<String, Object>(); // will be converted to JSON object
 		results.put("indexed", indexedIDs);
-		results.put("errors", idsWithErrors);
-		results.put("error_types", typesWithErrors);
-		results.put("stack_traces", idsWithStacktraces);
+		results.put("errors", new ArrayList());
 		return OTRepresentationConverter.convert(results);
 	}
 

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -168,7 +168,7 @@ public class studies extends ServerPlugin {
 	 * @throws MalformedURLException
 	 * @throws IOException
 	 */
-	@Description("DEPRECATED. Use the index_single_study service instead.")
+	@Description("DEPRECATED. Use the index_study service instead.")
 	@PluginTarget(GraphDatabaseService.class)
 	@Deprecated
 	// TODO: remove this from the next iteration of the API 

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -182,6 +183,8 @@ public class studies extends ServerPlugin {
 		
 		ArrayList<String> indexedIDs = new ArrayList<String>(urls.length);
 		HashMap<String, String> idsWithErrors = new HashMap<String, String>();
+		HashMap<String, String> idsWithStacktraces = new HashMap<String, String>();
+		HashMap<String, String> typesWithErrors = new HashMap<String, String>();
 		DatabaseManager manager = new DatabaseManager(graphDb);
 		for (int i = 0; i < urls.length; i++) {
 			try {
@@ -189,14 +192,17 @@ public class studies extends ServerPlugin {
 				manager.addOrReplaceStudy(study);
 				indexedIDs.add(study.getId());
 			} catch (Exception ex) {
+				idsWithStacktraces.put(urls[i], Arrays.toString(ex.getStackTrace()));
 				idsWithErrors.put(urls[i], ex.getMessage());
+				typesWithErrors.put(urls[i], ex.getClass().getName());
 			}
 		}
 		HashMap<String, Object> results = new HashMap<String, Object>(); // will be converted to JSON object
 		results.put("indexed", indexedIDs);
 		results.put("errors", idsWithErrors);
+		results.put("error_types", typesWithErrors);
+		results.put("stack_traces", idsWithStacktraces);
 		return OTRepresentationConverter.convert(results);
-
 	}
 
 

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -168,10 +168,10 @@ public class studies extends ServerPlugin {
 	 * @throws MalformedURLException
 	 * @throws IOException
 	 */
-	@Description("Index the nexson data at the provided urls. If a nexson study to be indexed has an identical ot:studyId value to a " +
-			"previously indexed study, then the previous information for that study will be replaced by the incoming nexson. Returns an " +
-			"array containing the study ids for the studies that were successfully read and indexed.")
+	@Description("DEPRECATED. Use the index_single_study service instead.")
 	@PluginTarget(GraphDatabaseService.class)
+	@Deprecated
+	// TODO: remove this from the next iteration of the API 
 	public Representation index_studies(@Source GraphDatabaseService graphDb,
 			@Description("remote nexson urls")
 			@Parameter(name = "urls", optional = false)
@@ -187,15 +187,9 @@ public class studies extends ServerPlugin {
 		HashMap<String, String> typesWithErrors = new HashMap<String, String>();
 		DatabaseManager manager = new DatabaseManager(graphDb);
 		for (int i = 0; i < urls.length; i++) {
-			try {
-				NexsonSource study = readRemoteNexson(urls[i]);
-				manager.addOrReplaceStudy(study);
-				indexedIDs.add(study.getId());
-			} catch (Exception ex) {
-				idsWithStacktraces.put(urls[i], Arrays.toString(ex.getStackTrace()));
-				idsWithErrors.put(urls[i], ex.getMessage());
-				typesWithErrors.put(urls[i], ex.getClass().getName());
-			}
+			NexsonSource study = readRemoteNexson(urls[i]);
+			manager.addOrReplaceStudy(study);
+			indexedIDs.add(study.getId());
 		}
 		HashMap<String, Object> results = new HashMap<String, Object>(); // will be converted to JSON object
 		results.put("indexed", indexedIDs);
@@ -206,6 +200,32 @@ public class studies extends ServerPlugin {
 	}
 
 
+	/**
+	 * Index the nexson data accessible at the passed url(s).
+	 * @param graphDb
+	 * @param url
+	 * @return
+	 * @throws MalformedURLException
+	 * @throws IOException
+	 */
+	@Description("Index the nexson study at the provided url. If the study to be indexed has an identical ot:studyId value to a " +
+	"previously indexed study, then the previous information for that study will be replaced by the incoming nexson. Returns true " +
+	"on successful indexing, or reports an error if one is encountered.")
+	@PluginTarget(GraphDatabaseService.class)
+	public Representation index_single_study(@Source GraphDatabaseService graphDb,
+			@Description("remote nexson url")
+			@Parameter(name = "url", optional = false)
+			String url) throws MalformedURLException, IOException {
+
+		DatabaseManager manager = new DatabaseManager(graphDb);
+
+		NexsonSource study = readRemoteNexson(url);
+		manager.addOrReplaceStudy(study);
+
+		return OTRepresentationConverter.convert(true);
+	}
+
+	
 	/**
 	 * Remove nexson data (if found) by study id
 	 * @param graphDb

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -212,7 +212,7 @@ public class studies extends ServerPlugin {
 	"previously indexed study, then the previous information for that study will be replaced by the incoming nexson. Returns true " +
 	"on successful indexing, or reports an error if one is encountered.")
 	@PluginTarget(GraphDatabaseService.class)
-	public Representation index_single_study(@Source GraphDatabaseService graphDb,
+	public Representation index_study(@Source GraphDatabaseService graphDb,
 			@Description("remote nexson url")
 			@Parameter(name = "url", optional = false)
 			String url) throws MalformedURLException, IOException {

--- a/src/main/java/org/opentree/oti/plugins/studies.java
+++ b/src/main/java/org/opentree/oti/plugins/studies.java
@@ -190,7 +190,7 @@ public class studies extends ServerPlugin {
 		}
 		HashMap<String, Object> results = new HashMap<String, Object>(); // will be converted to JSON object
 		results.put("indexed", indexedIDs);
-		results.put("errors", new ArrayList());
+		results.put("errors", new HashMap());
 		return OTRepresentationConverter.convert(results);
 	}
 


### PR DESCRIPTION
The NexsonNode and NexsonTree classes were missing some important methods, and OTI was not properly updated to use them. See #38. This should fix that.

Also new behavior on the (now deprecated!) index_studies service: it will throw the first exception it encounters instead of saving them up. Because of this, the json field for "errors" is obsolete and has been removed from the response. This service is now DEPRECATED. It has been replaced by the new service below:

New service: index_study will accept a single url, and attempt to index the study. If an error is encountered, and exception with be thrown (and then caught by neo4j), resulting in the return of information about the error. Otherwise, the service just returns 'true' on success.

Depends on https://github.com/OpenTreeOfLife/ot-base/pull/15